### PR TITLE
워크플로 트리깅 방식 수정

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -1,15 +1,14 @@
 name: Continuous Deployment to Dev
 
 on:
+  repository_dispatch:
+    types: [trigger-cd]
   workflow_dispatch:
     inputs:
       version:
         description: 'Version to deploy (e.g., v1.2.3)'
         required: true
         type: string
-  push:
-    branches:
-      - main
 
 env:
   AWS_REGION: ap-northeast-2
@@ -39,10 +38,13 @@ jobs:
       - name: Determine version to deploy
         id: determine-version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "VERSION=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           else
-            echo "VERSION=latest" >> $GITHUB_OUTPUT
+            echo "Error: Unexpected event type"
+            exit 1
           fi
 
       - name: Check if image exists in ECR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,3 +141,13 @@ jobs:
           git config user.email github-actions@github.com
           git tag ${{ steps.generate-version.outputs.version }}
           git push origin ${{ steps.generate-version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+
+      - name: Trigger CD (DEV) Workflow
+        if: success()
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: trigger-cd
+          client-payload: '{"version": "${{ steps.generate-version.outputs.version }}"}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 개발 환경에 대한 지속적 배포 워크플로우가 `repository_dispatch` 이벤트를 통해 트리거될 수 있도록 업데이트되었습니다.
	- CI 워크플로우에 새로운 단계가 추가되어 성공적인 이전 단계 후에 CD 워크플로우를 트리거합니다.

- **버그 수정**
	- 이벤트 타입이 유효하지 않을 경우 오류 메시지를 출력하고 작업이 종료되도록 조건을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->