### PR TITLE
✨ API 인증 필터 구현

### DIFF
--- a/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/support/config/OpenApiConfig.kt
+++ b/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/support/config/OpenApiConfig.kt
@@ -1,0 +1,20 @@
+package com.threedays.bootstrap.api.support.config
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.security.SecurityScheme
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+@OpenAPIDefinition(
+    info = Info(title = "3days API"),
+)
+@SecurityScheme(
+    name = "BearerAuth",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT"
+)
+class OpenApiConfig

--- a/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/support/exception/ControllerAdvice.kt
+++ b/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/support/exception/ControllerAdvice.kt
@@ -1,4 +1,4 @@
-package com.threedays.bootstrap.api.support
+package com.threedays.bootstrap.api.support.exception
 
 import com.threedays.oas.model.ErrorResponse
 import com.threedays.support.common.base.exception.CustomException

--- a/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/support/exception/GlobalExceptionHandlingFilter.kt
+++ b/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/support/exception/GlobalExceptionHandlingFilter.kt
@@ -1,0 +1,59 @@
+package com.threedays.bootstrap.api.support.exception
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.threedays.domain.auth.exception.AuthException
+import com.threedays.oas.model.ErrorResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.OffsetDateTime
+
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class GlobalExceptionHandlingFilter(
+    private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+
+    companion object {
+
+        private val log = KotlinLogging.logger { }
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (exception: AuthException) {
+            log.error(exception) { "AuthException occurred" }
+            handleAuthException(response, exception)
+        }
+    }
+
+    private fun handleAuthException(
+        response: HttpServletResponse,
+        exception: AuthException,
+    ) {
+        val errorResponse = ErrorResponse(
+            code = exception.code,
+            message = exception.message,
+            time = OffsetDateTime.now(),
+            type = exception.type,
+        )
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType =
+            "${MediaType.APPLICATION_JSON_VALUE};charset=${Charsets.UTF_8.name()}"
+        response.writer.write(objectMapper.writeValueAsString(errorResponse))
+    }
+
+}

--- a/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/support/security/AuthenticationFilter.kt
+++ b/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/support/security/AuthenticationFilter.kt
@@ -1,0 +1,53 @@
+package com.threedays.bootstrap.api.support.security
+
+import com.threedays.application.auth.config.AuthProperties
+import com.threedays.domain.auth.entity.AccessToken
+import com.threedays.domain.auth.vo.UserAuthentication
+import com.threedays.support.common.security.SecurityContext
+import com.threedays.support.common.security.SecurityContextHolder
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class AuthenticationFilter(
+    private val authProperties: AuthProperties,
+) : OncePerRequestFilter() {
+
+    companion object {
+
+        const val AUTH_TOKEN_HEADER = "Authorization"
+        const val BEARER_PREFIX = "Bearer "
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        extractToken(request)?.let { setSecurityContext(it) }
+        filterChain.doFilter(request, response)
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun setSecurityContext(token: String) {
+        AccessToken
+            .verify(token, authProperties.tokenSecret)
+            .let { UserAuthentication(it.userId) }
+            .let { SecurityContext(it) }
+            .let { SecurityContextHolder.setContext(it) }
+    }
+
+    private fun extractToken(request: HttpServletRequest): String? {
+        val bearerToken: String? = request.getHeader(AUTH_TOKEN_HEADER)
+
+        return if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
+            bearerToken.substring(BEARER_PREFIX.length)
+        } else {
+            null
+        }
+    }
+
+}

--- a/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/user/UserController.kt
+++ b/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/user/UserController.kt
@@ -2,14 +2,18 @@ package com.threedays.bootstrap.api.user
 
 import com.threedays.application.user.port.inbound.RegisterUser
 import com.threedays.domain.auth.vo.PhoneNumber
+import com.threedays.domain.auth.vo.UserAuthentication
 import com.threedays.domain.user.entity.JobOccupation
 import com.threedays.domain.user.entity.User
 import com.threedays.domain.user.entity.UserDesiredPartner
 import com.threedays.domain.user.vo.Gender
 import com.threedays.oas.api.UsersApi
+import com.threedays.oas.model.GetMyUserInfoResponse
 import com.threedays.oas.model.RegisterUserRequest
 import com.threedays.oas.model.TokenResponse
 import com.threedays.support.common.base.domain.UUIDTypeId
+import com.threedays.support.common.security.SecurityContext
+import com.threedays.support.common.security.SecurityContextHolder
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -17,7 +21,7 @@ import java.time.Year
 
 @RestController
 class UserController(
-    private val registerUser: RegisterUser
+    private val registerUser: RegisterUser,
 ) : UsersApi {
 
     override fun registerUser(
@@ -54,4 +58,13 @@ class UserController(
         }
     }
 
+    override fun getMyUserInfo(): ResponseEntity<GetMyUserInfoResponse> {
+        val securityContext: SecurityContext<UserAuthentication>? =
+            SecurityContextHolder.getContext()
+
+        println("securityContext: ${securityContext?.authentication?.userId}")
+        // TODO: Implement this method
+
+        throw NotImplementedError()
+    }
 }

--- a/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/user/UserController.kt
+++ b/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/user/UserController.kt
@@ -2,7 +2,6 @@ package com.threedays.bootstrap.api.user
 
 import com.threedays.application.user.port.inbound.RegisterUser
 import com.threedays.domain.auth.vo.PhoneNumber
-import com.threedays.domain.auth.vo.UserAuthentication
 import com.threedays.domain.user.entity.JobOccupation
 import com.threedays.domain.user.entity.User
 import com.threedays.domain.user.entity.UserDesiredPartner
@@ -12,8 +11,6 @@ import com.threedays.oas.model.GetMyUserInfoResponse
 import com.threedays.oas.model.RegisterUserRequest
 import com.threedays.oas.model.TokenResponse
 import com.threedays.support.common.base.domain.UUIDTypeId
-import com.threedays.support.common.security.SecurityContext
-import com.threedays.support.common.security.SecurityContextHolder
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -59,12 +56,7 @@ class UserController(
     }
 
     override fun getMyUserInfo(): ResponseEntity<GetMyUserInfoResponse> {
-        val securityContext: SecurityContext<UserAuthentication>? =
-            SecurityContextHolder.getContext()
-
-        println("securityContext: ${securityContext?.authentication?.userId}")
         // TODO: Implement this method
-
         throw NotImplementedError()
     }
 }

--- a/domain/src/main/kotlin/com/threedays/domain/auth/vo/UserAuthentication.kt
+++ b/domain/src/main/kotlin/com/threedays/domain/auth/vo/UserAuthentication.kt
@@ -1,0 +1,8 @@
+package com.threedays.domain.auth.vo
+
+import com.threedays.domain.user.entity.User
+import com.threedays.support.common.security.Authentication
+
+data class UserAuthentication(
+    val userId: User.Id,
+) : Authentication

--- a/support/common/src/main/kotlin/com/threedays/support/common/security/Authentication.kt
+++ b/support/common/src/main/kotlin/com/threedays/support/common/security/Authentication.kt
@@ -1,0 +1,3 @@
+package com.threedays.support.common.security
+
+interface Authentication

--- a/support/common/src/main/kotlin/com/threedays/support/common/security/SecurityContext.kt
+++ b/support/common/src/main/kotlin/com/threedays/support/common/security/SecurityContext.kt
@@ -1,0 +1,5 @@
+package com.threedays.support.common.security
+
+class SecurityContext<T: Authentication>(
+    val authentication: T,
+)

--- a/support/common/src/main/kotlin/com/threedays/support/common/security/SecurityContextHolder.kt
+++ b/support/common/src/main/kotlin/com/threedays/support/common/security/SecurityContextHolder.kt
@@ -1,0 +1,20 @@
+package com.threedays.support.common.security
+
+object SecurityContextHolder {
+
+    private val contextHolder: ThreadLocal<SecurityContext<out Authentication>> = ThreadLocal()
+
+    fun <T: Authentication> getContext(): SecurityContext<T>? {
+        @Suppress("UNCHECKED_CAST")
+        return contextHolder.get() as SecurityContext<T>?
+    }
+
+    fun setContext(context: SecurityContext<out Authentication>) {
+        contextHolder.set(context)
+    }
+
+    fun clearContext() {
+        contextHolder.remove()
+    }
+
+}


### PR DESCRIPTION
- open api 스키마 token 넣을수 있도록 수정
- 인증 필터 및 security context 구현


## 논의사항

UserController 보면


```kotlin
    override fun getMyUserInfo(): ResponseEntity<GetMyUserInfoResponse> {
        val securityContext: SecurityContext<UserAuthentication>? =
            SecurityContextHolder.getContext()

        println("securityContext: ${securityContext?.authentication?.userId}")
        // TODO: Implement this method

        throw NotImplementedError()
    }
```

이렇게 securityContext를 get하는 부분이 있는데요, 아무래도 다음 인증이 필요한 API를 작성할때 똑같은 코드가 또나올 겁니다.


WEAVE할때는 Interceptor로 파라미터 수정해서 집어넣어줬었는데, 지금은 openapi generator로 인해 생성되는 코드이다 보니까 메서드 파라미터 수정이 불가능합니다. 


그래서 제안드리는건 별도로 `withUserAuthentication` 라는 고차함수를 정의하구요 

```kotlin
fun <T> withUserAuthentication(block: (UserAuthentication) -> T): T {
    val securityContext: SecurityContext<UserAuthentication>? =
        SecurityContextHolder.getContext()

    val userAuthentication = securityContext?.authentication
        ?: throw IllegalStateException("User is not authenticated")

    return block(userAuthentication)
}
```

아래처럼 처리하는거 어떻게 생각하시나요?

```kotlin
override fun getMyUserInfo(): ResponseEntity<GetMyUserInfoResponse> {
    return withUserAuthentication { userAuthentication ->
        // 비즈니스 로직
        val userInfo = GetMyUserInfoResponse(
            id = userAuthentication.user.id,
            name = userAuthentication.user.name
        )
        ResponseEntity.ok(userInfo)
    }
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- OpenAPI 문서 구성을 위한 `OpenApiConfig` 클래스 추가.
	- 인증을 처리하는 `AuthenticationFilter` 클래스 추가.
	- 사용자 정보를 가져오는 `getMyUserInfo` 메서드가 `UserController`에 추가되었으나 구현은 미완료.
	- `UserAuthentication`, `Authentication`, `SecurityContext`, `SecurityContextHolder` 클래스 및 인터페이스 추가.
	- 인증 관련 예외 처리를 위한 `GlobalExceptionHandlingFilter` 클래스 추가.

- **버그 수정**
	- `ControllerAdvice` 클래스의 패키지 구조 변경으로 예외 처리의 목적이 명확해짐.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->