### PR TITLE
feat(user): implement delete my user

### DIFF
--- a/application/src/main/kotlin/com/threedays/application/auth/port/inbound/ClearTokens.kt
+++ b/application/src/main/kotlin/com/threedays/application/auth/port/inbound/ClearTokens.kt
@@ -1,0 +1,10 @@
+package com.threedays.application.auth.port.inbound
+
+import com.threedays.domain.user.entity.User
+
+interface ClearTokens {
+
+    fun invoke(command: Command)
+
+    data class Command(val userId: User.Id)
+}

--- a/application/src/main/kotlin/com/threedays/application/auth/service/AuthTokenService.kt
+++ b/application/src/main/kotlin/com/threedays/application/auth/service/AuthTokenService.kt
@@ -1,6 +1,7 @@
 package com.threedays.application.auth.service
 
 import com.threedays.application.auth.config.AuthProperties
+import com.threedays.application.auth.port.inbound.ClearTokens
 import com.threedays.application.auth.port.inbound.IssueLoginTokens
 import com.threedays.application.auth.port.inbound.RefreshLoginTokens
 import com.threedays.domain.auth.entity.AccessToken
@@ -13,9 +14,8 @@ import org.springframework.stereotype.Service
 @Service
 class AuthTokenService(
     private val authProperties: AuthProperties,
-    private val refreshTokenRepository: RefreshTokenRepository
-) : IssueLoginTokens,
-    RefreshLoginTokens {
+    private val refreshTokenRepository: RefreshTokenRepository,
+) : IssueLoginTokens, RefreshLoginTokens, ClearTokens {
 
     override fun invoke(command: IssueLoginTokens.Command): IssueLoginTokens.Result {
         val user: User = command.user
@@ -76,4 +76,9 @@ class AuthTokenService(
             secret = authProperties.tokenSecret
         )
     }
+
+    override fun invoke(command: ClearTokens.Command) {
+        refreshTokenRepository.delete(command.userId)
+    }
+
 }

--- a/application/src/main/kotlin/com/threedays/application/user/port/inbound/DeleteMyUser.kt
+++ b/application/src/main/kotlin/com/threedays/application/user/port/inbound/DeleteMyUser.kt
@@ -1,0 +1,16 @@
+package com.threedays.application.user.port.inbound
+
+import com.threedays.domain.user.entity.User
+
+interface DeleteMyUser {
+
+    fun invoke(command: Command)
+
+    /**
+     * 회원 가입 요청
+     * @param userId 회원 ID
+     */
+    data class Command(
+        val userId: User.Id,
+    )
+}

--- a/application/src/main/kotlin/com/threedays/application/user/port/inbound/DeleteMyUser.kt
+++ b/application/src/main/kotlin/com/threedays/application/user/port/inbound/DeleteMyUser.kt
@@ -7,8 +7,8 @@ interface DeleteMyUser {
     fun invoke(command: Command)
 
     /**
-     * 회원 가입 요청
-     * @param userId 회원 ID
+     * 회원 삭제 요청
+     * @param userId 삭제할 회원 ID
      */
     data class Command(
         val userId: User.Id,

--- a/application/src/main/kotlin/com/threedays/application/user/service/UserService.kt
+++ b/application/src/main/kotlin/com/threedays/application/user/service/UserService.kt
@@ -1,7 +1,9 @@
 package com.threedays.application.user.service
 
 import com.threedays.application.auth.config.AuthProperties
+import com.threedays.application.auth.port.inbound.ClearTokens
 import com.threedays.application.auth.port.inbound.IssueLoginTokens
+import com.threedays.application.user.port.inbound.DeleteMyUser
 import com.threedays.application.user.port.inbound.RegisterUser
 import com.threedays.application.user.port.inbound.UpdateConnectionStatus
 import com.threedays.domain.user.entity.Company
@@ -19,8 +21,9 @@ class UserService(
     private val locationQueryRepository: LocationQueryRepository,
     private val companyQueryRepository: CompanyQueryRepository,
     private val issueLoginTokens: IssueLoginTokens,
+    private val clearTokens: ClearTokens,
     private val authProperties: AuthProperties,
-) : RegisterUser, UpdateConnectionStatus {
+) : RegisterUser, UpdateConnectionStatus, DeleteMyUser {
 
     @Transactional
     override fun invoke(command: RegisterUser.Command): RegisterUser.Result {
@@ -60,4 +63,11 @@ class UserService(
             .updateConnectionStatus(command.status)
             .also { userRepository.save(it) }
     }
+
+    override fun invoke(command: DeleteMyUser.Command) {
+        // TODO(connection): 현재 connecting 여부를 체크하고 있는 경우 에러를 반환해야함.
+        userRepository.delete(command.userId)
+        clearTokens.invoke(ClearTokens.Command(command.userId))
+    }
+
 }

--- a/application/src/main/kotlin/com/threedays/application/user/service/UserService.kt
+++ b/application/src/main/kotlin/com/threedays/application/user/service/UserService.kt
@@ -64,6 +64,7 @@ class UserService(
             .also { userRepository.save(it) }
     }
 
+    @Transactional
     override fun invoke(command: DeleteMyUser.Command) {
         // TODO(connection): 현재 connecting 여부를 체크하고 있는 경우 에러를 반환해야함.
         userRepository.delete(command.userId)

--- a/application/src/test/kotlin/com/threedays/application/auth/service/AuthTokenServiceTest.kt
+++ b/application/src/test/kotlin/com/threedays/application/auth/service/AuthTokenServiceTest.kt
@@ -224,7 +224,7 @@ class AuthTokenServiceTest : DescribeSpec({
                 val refreshToken = RefreshToken.generate(
                     secret = secret,
                     expirationSeconds = refreshTokenExpirationSeconds.toLong(),
-                    userId = UUIDTypeId.random<User.Id>()
+                    userId = userId
                 )
 
                 refreshTokenRepository.save(refreshToken, refreshTokenExpirationSeconds.toLong())

--- a/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/user/UserController.kt
+++ b/bootstrap/api/src/main/kotlin/com/threedays/bootstrap/api/user/UserController.kt
@@ -1,6 +1,7 @@
 package com.threedays.bootstrap.api.user
 
 import com.threedays.application.user.port.inbound.CompleteUserProfileImageUpload
+import com.threedays.application.user.port.inbound.DeleteMyUser
 import com.threedays.application.user.port.inbound.DeleteProfileWidget
 import com.threedays.application.user.port.inbound.DeleteUserProfileImage
 import com.threedays.application.user.port.inbound.GetUserProfileImageUploadUrl
@@ -45,6 +46,7 @@ import java.util.*
 @RestController
 class UserController(
     private val registerUser: RegisterUser,
+    private val deleteMyUser: DeleteMyUser,
     private val putProfileWidget: PutProfileWidget,
     private val userRepository: UserRepository,
     private val deleteProfileWidget: DeleteProfileWidget,
@@ -94,6 +96,14 @@ class UserController(
                 .status(HttpStatus.CREATED)
                 .body(it)
         }
+    }
+
+    override fun deleteMyUser(): ResponseEntity<Unit> = withUserAuthentication { userAuthentication ->
+        userRepository.get(userAuthentication.userId).let { user ->
+            deleteMyUser.invoke(DeleteMyUser.Command(userId = user.id))
+
+        }
+        ResponseEntity.noContent().build()
     }
 
     override fun getMyUserInfo(): ResponseEntity<GetMyUserInfoResponse> =
@@ -227,7 +237,7 @@ class UserController(
         }
 
     override fun updateConnectionStatus(
-        updateConnectionStatusRequest: UpdateConnectionStatusRequest
+        updateConnectionStatusRequest: UpdateConnectionStatusRequest,
     ): ResponseEntity<UpdateConnectionStatusResponse> =
         withUserAuthentication { authentication ->
             val command = UpdateConnectionStatus.Command(

--- a/domain/src/main/kotlin/com/threedays/domain/auth/repository/RefreshTokenRepository.kt
+++ b/domain/src/main/kotlin/com/threedays/domain/auth/repository/RefreshTokenRepository.kt
@@ -12,4 +12,6 @@ interface RefreshTokenRepository {
 
     fun find(userId: User.Id): RefreshToken?
 
+    fun delete(userId: User.Id)
+
 }

--- a/domain/src/testFixtures/kotlin/com/threedays/domain/auth/repository/RefreshTokenRepositorySpy.kt
+++ b/domain/src/testFixtures/kotlin/com/threedays/domain/auth/repository/RefreshTokenRepositorySpy.kt
@@ -10,13 +10,17 @@ class RefreshTokenRepositorySpy : RefreshTokenRepository {
 
     override fun save(
         refreshToken: RefreshToken,
-        expiresIn: Long
+        expiresIn: Long,
     ) {
         store[refreshToken.userId] = refreshToken
     }
 
     override fun find(userId: User.Id): RefreshToken? {
         return store[userId]
+    }
+
+    override fun delete(userId: User.Id) {
+        store.remove(userId)
     }
 
     fun clear() {

--- a/infrastructure/redis/src/main/kotlin/com/threedays/redis/auth/RefreshTokenRedisAdapter.kt
+++ b/infrastructure/redis/src/main/kotlin/com/threedays/redis/auth/RefreshTokenRedisAdapter.kt
@@ -26,4 +26,8 @@ class RefreshTokenRedisAdapter(
             .orElse(null)
     }
 
+    override fun delete(userId: User.Id) {
+        refreshTokenRedisRepository.deleteById(userId.value.toString())
+    }
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 계정 삭제 기능이 추가되어, 사용자가 계정을 삭제할 때 연관된 인증 토큰이 자동으로 제거됩니다.
	- 사용자 삭제 요청 시 인증된 사용자 ID를 기반으로 계정 삭제 및 토큰 제거가 수행됩니다.
	- 인증 토큰 삭제 기능이 추가되어 특정 사용자와 연관된 토큰을 삭제할 수 있습니다.
	- 새로 추가된 메소드를 통해 사용자 ID에 따라 리프레시 토큰을 삭제할 수 있습니다.
	- `fixture-monkey` 라이브러리의 버전이 1.0.24에서 1.1.8로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->